### PR TITLE
PLEXIL-174 Prevent makeExecApplication from crashing when called again

### DIFF
--- a/src/app-framework/ExecListenerFactory.cc
+++ b/src/app-framework/ExecListenerFactory.cc
@@ -143,7 +143,6 @@ namespace PLEXIL
       warn("Attempted to register an exec listener factory for name \""
            << name.c_str()
            << "\" twice, ignoring.");
-      delete factory;
       return;
     }
     factoryMap()[name] = ExecListenerFactoryPtr(factory);

--- a/src/app-framework/ExecListenerFilterFactory.cc
+++ b/src/app-framework/ExecListenerFilterFactory.cc
@@ -148,7 +148,6 @@ namespace PLEXIL
       warn("Attempted to register an exec listener filter factory for name \""
            << name.c_str()
            << "\" twice, ignoring.");
-      delete factory;
       return;
     }
     factoryMap()[name] = ExecListenerFilterFactoryPtr(factory);


### PR DESCRIPTION
We know that only instance of `ExecApplication` can exist per process.  However, it should be fine to delete the existing instance and then create a new one.  Doing so caused a crash before this fix. The problem was simply that a passed in pointer to live data was deleted when it shouldn't have been.

### Test ###

First, run this program without the fix and it should crash after the message "Created first ExecApplication":

```
#include <iostream>
#include "ExecApplication.hh"

using namespace std;
using namespace PLEXIL;

int main ()
{
  cout << "Starting Exec Test..." << endl;
  ExecApplication* app = makeExecApplication();
  cout << "Created first ExecApplication." << endl;
  delete app;
  app = makeExecApplication();
  cout << "Finished Exec Test." << endl;
  return 0;
}
```
With the fix, it should complete successfully.