### PR TITLE
PLEXIL-176 Make ExecListener notify methods non-const

### DIFF
--- a/src/app-framework/ExecListener.cc
+++ b/src/app-framework/ExecListener.cc
@@ -47,7 +47,7 @@ namespace PLEXIL
    * @brief Notify that nodes have changed state.
    * @param Vector of node state transition info.
    */
-  void ExecListener::notifyOfTransitions(const std::vector<NodeTransition>& transitions) const
+  void ExecListener::notifyOfTransitions(const std::vector<NodeTransition>& transitions)
   {
     this->implementNotifyNodeTransitions(transitions);
   }
@@ -197,7 +197,7 @@ namespace PLEXIL
    * @note Current states are accessible via the node.
    * @note This default method is a convenience for backward compatibility.
    */
-  void ExecListener::implementNotifyNodeTransitions(const std::vector<NodeTransition>& transitions) const
+  void ExecListener::implementNotifyNodeTransitions(const std::vector<NodeTransition>& transitions)
   {
     if (!m_filter) {
       for (NodeTransition const &transition : transitions)
@@ -216,7 +216,7 @@ namespace PLEXIL
    * @note This default method does nothing.
    */
   void
-  ExecListener::implementNotifyNodeTransition(NodeTransition const & /* transition */) const
+  ExecListener::implementNotifyNodeTransition(NodeTransition const & /* transition */)
   {
   }
 

--- a/src/app-framework/ExecListener.cc
+++ b/src/app-framework/ExecListener.cc
@@ -58,7 +58,7 @@ namespace PLEXIL
    * @param parent The name of the parent node under which this plan will be inserted.
    */
   void
-  ExecListener::notifyOfAddPlan(pugi::xml_node const plan) const
+  ExecListener::notifyOfAddPlan(pugi::xml_node const plan)
   {
     if (!m_filter
         || m_filter->reportAddPlan(plan))
@@ -70,7 +70,7 @@ namespace PLEXIL
    * @param libNode The intermediate representation of the plan.
    */
   void 
-  ExecListener::notifyOfAddLibrary(pugi::xml_node const libNode) const
+  ExecListener::notifyOfAddLibrary(pugi::xml_node const libNode)
   {
     if (!m_filter
         || m_filter->reportAddLibrary(libNode))
@@ -86,7 +86,7 @@ namespace PLEXIL
   void
   ExecListener::notifyOfAssignment(Expression const *dest,
                                    const std::string& destName,
-                                   const Value& value) const
+                                   const Value& value)
   {
     if (!m_filter
         || m_filter->reportAssignment(dest, destName, value))
@@ -226,7 +226,7 @@ namespace PLEXIL
    * @param parent The name of the parent node under which this plan will be inserted.
    * @note The default method does nothing.
    */
-  void ExecListener::implementNotifyAddPlan(pugi::xml_node const /* plan */) const
+  void ExecListener::implementNotifyAddPlan(pugi::xml_node const /* plan */)
   {
   }
 
@@ -235,7 +235,7 @@ namespace PLEXIL
    * @param libNode The intermediate representation of the plan.
    * @note The default method does nothing.
    */
-  void ExecListener::implementNotifyAddLibrary(pugi::xml_node const /* libNode */) const
+  void ExecListener::implementNotifyAddLibrary(pugi::xml_node const /* libNode */)
   {
   }
 
@@ -247,7 +247,7 @@ namespace PLEXIL
    */
   void ExecListener::implementNotifyAssignment(Expression const * /* dest */,
                                                const std::string& /* destName */,
-                                               const Value& /* value */) const
+                                               const Value& /* value */)
   {
   }
 

--- a/src/app-framework/ExecListener.hh
+++ b/src/app-framework/ExecListener.hh
@@ -71,7 +71,7 @@ namespace PLEXIL
 
     //! Notify that one or more nodes have changed state.
     //! @param Vector of node state transition info.
-    void notifyOfTransitions(std::vector<NodeTransition> const &transitions) const;
+    void notifyOfTransitions(std::vector<NodeTransition> const &transitions);
 
     //! Notify that a variable assignment has been performed.
     //! @param dest The Expression being assigned to.
@@ -133,7 +133,7 @@ namespace PLEXIL
     //!      implementNotifyNodeTransition() (below). Derived classes
     //!      may implement their own methods as an optimization.
     virtual void
-    implementNotifyNodeTransitions(std::vector<NodeTransition> const & /* transitions */) const;
+    implementNotifyNodeTransitions(std::vector<NodeTransition> const & /* transitions */);
 
     //
     // API to be implemented by derived classes
@@ -146,7 +146,7 @@ namespace PLEXIL
     //!       implementNotifyNodeTransition() (above), as appropriate
     //!       to the application.
     virtual void
-    implementNotifyNodeTransition(NodeTransition const & /* transition */) const;
+    implementNotifyNodeTransition(NodeTransition const & /* transition */);
 
     //! Notify that a plan has been received by the Exec.
     //! @param plan The XML representation of the plan.

--- a/src/app-framework/ExecListener.hh
+++ b/src/app-framework/ExecListener.hh
@@ -79,7 +79,7 @@ namespace PLEXIL
     //! @param value The value (in internal Exec representation) being assigned.
     void notifyOfAssignment(Expression const *dest,
                             std::string const &destName,
-                            Value const &value) const;
+                            Value const &value);
 
     //
     // API to application
@@ -87,11 +87,11 @@ namespace PLEXIL
 
     //! Notify that a new plan has been received by the Exec.
     //! @param plan The XML representation of the plan.
-    void notifyOfAddPlan(pugi::xml_node const plan) const;
+    void notifyOfAddPlan(pugi::xml_node const plan);
 
     //! Notify that a new library node has been received by the Exec.
     // @param libNode The XML representation of the plan.
-    void notifyOfAddLibrary(pugi::xml_node const libNode) const;
+    void notifyOfAddLibrary(pugi::xml_node const libNode);
 
     //
     // Lifecycle API which can be overridden by derived classes
@@ -151,12 +151,12 @@ namespace PLEXIL
     //! Notify that a plan has been received by the Exec.
     //! @param plan The XML representation of the plan.
     //! @note The default method does nothing.
-    virtual void implementNotifyAddPlan(pugi::xml_node const /* plan */) const;
+    virtual void implementNotifyAddPlan(pugi::xml_node const /* plan */);
 
     //! Notify that a library node has been received by the Exec.
     //! @param libNode The XML representation of the plan.
     //! @note The default method does nothing.
-    virtual void implementNotifyAddLibrary(pugi::xml_node const /* libNode */) const;
+    virtual void implementNotifyAddLibrary(pugi::xml_node const /* libNode */);
 
     //! Notify that a variable assignment has been performed.
     //! @param dest The Expression being assigned to.
@@ -165,7 +165,7 @@ namespace PLEXIL
     //! @note The default method does nothing.
     virtual void implementNotifyAssignment(Expression const * /* dest */,
                                            std::string const & /* destName */,
-                                           Value const & /* value */) const;
+                                           Value const & /* value */);
 
 
     //

--- a/src/app-framework/Launcher.cc
+++ b/src/app-framework/Launcher.cc
@@ -75,7 +75,7 @@ namespace PLEXIL
 
     //! Wrapper method to ensure we don't notify the Exec too often.
     virtual void
-    implementNotifyNodeTransitions(std::vector<NodeTransition> const &transitions) const override
+    implementNotifyNodeTransitions(std::vector<NodeTransition> const &transitions) override
     {
       bool notify = false;
       for (NodeTransition const &t : transitions) {

--- a/src/app-framework/Makefile.am
+++ b/src/app-framework/Makefile.am
@@ -82,14 +82,16 @@ libPlexilAppFramework_la_LIBADD = @top_builddir@/xml-parser/libPlexilXmlParser.l
  @top_builddir@/value/libPlexilValue.la \
  @top_builddir@/utils/libPlexilUtils.la
 
-if MODULE_TESTS_OPT
-  bin_PROGRAMS = test/timebase-test
-  test_timebase_test_SOURCES = test/timebase-test.cc Timebase.cc TimebaseFactory.cc
-  test_timebase_test_CPPFLAGS = $(AM_CPPFLAGS) \
-   -I@top_srcdir@/third-party/pugixml/src \
-   -I@top_srcdir@/intfc \
-   -I@top_srcdir@/utils
-  test_timebase_test_LDADD = @top_builddir@/third-party/pugixml/src/libpugixml.la \
-   @top_builddir@/intfc/libPlexilIntfc.la \
-   @top_builddir@/utils/libPlexilUtils.la
+if THREADS_OPT
+	if MODULE_TESTS_OPT
+		bin_PROGRAMS = test/timebase-test
+		test_timebase_test_SOURCES = test/timebase-test.cc Timebase.cc TimebaseFactory.cc
+		test_timebase_test_CPPFLAGS = $(AM_CPPFLAGS) \
+		 -I@top_srcdir@/third-party/pugixml/src \
+		 -I@top_srcdir@/intfc \
+		 -I@top_srcdir@/utils
+		test_timebase_test_LDADD = @top_builddir@/third-party/pugixml/src/libpugixml.la \
+		 @top_builddir@/intfc/libPlexilIntfc.la \
+		 @top_builddir@/utils/libPlexilUtils.la
+	endif
 endif

--- a/src/interfaces/LuvListener/LuvListener.cc
+++ b/src/interfaces/LuvListener/LuvListener.cc
@@ -140,7 +140,7 @@ namespace PLEXIL
      * @param plan The XML representation of the plan.
      */
     virtual void
-    implementNotifyAddPlan(pugi::xml_node const plan) const override
+    implementNotifyAddPlan(pugi::xml_node const plan) override
     {
       debugMsg("LuvListener:implementNotifyAddPlan", " entered");
       if (m_socket) {
@@ -156,7 +156,7 @@ namespace PLEXIL
      * @param libNode The XML representation of the library node.
      */
     virtual void
-    implementNotifyAddLibrary(pugi::xml_node const libNode) const override
+    implementNotifyAddLibrary(pugi::xml_node const libNode) override
     {
       if (m_socket) {
         sendPlanInfo();
@@ -175,7 +175,7 @@ namespace PLEXIL
     virtual void 
     implementNotifyAssignment(Expression const *dest,
                               std::string const &destName,
-                              Value const &value) const override
+                              Value const &value) override
     {
       if (m_socket) {
         std::ostringstream s;

--- a/src/interfaces/LuvListener/LuvListener.cc
+++ b/src/interfaces/LuvListener/LuvListener.cc
@@ -124,7 +124,7 @@ namespace PLEXIL
      * @param transition Const reference to the transition record.
      */
     virtual void
-    implementNotifyNodeTransition(NodeTransition const &trans) const override
+    implementNotifyNodeTransition(NodeTransition const &trans) override
     {
       debugMsg("LuvListener:implementNotifyNodeTransition",
                " for " << trans.node->getNodeId());

--- a/src/interfaces/PlanDebugListener/PlanDebugListener.cc
+++ b/src/interfaces/PlanDebugListener/PlanDebugListener.cc
@@ -59,7 +59,7 @@ namespace PLEXIL
     // interface may be in order.
 
     virtual void 
-    implementNotifyNodeTransition(NodeTransition const &trans) const override
+    implementNotifyNodeTransition(NodeTransition const &trans) override
     {
       NodeImpl *node = dynamic_cast<NodeImpl *>(trans.node);
       assertTrueMsg(node,


### PR DESCRIPTION
This is a simple change that removes `const` from notification methods in `ExecListener` .  The motivation is supporting the DSA project that would like listeners to update counters and such.

It also adds a fix that prevents the build of app framework tests when threads are turned off.