### PR TITLE
GitHub issue #5: Fix IPC build issues

### DIFF
--- a/CAVEATS
+++ b/CAVEATS
@@ -1,7 +1,7 @@
 This file, plexil/CAVEATS, lists known bugs and issues in this version
 of PLEXIL.
 
-Build: 
+Build:
 
  * If the GNU autotools installed on your system are a different
    version from the ones used to build this release, you may encounter
@@ -71,7 +71,7 @@ Standard Plexil language:
 
  * Node timepoints cannot be assigned to variables.
 
-Plexil Viewer: 
+Plexil Viewer:
 
  * Support for the PLEXIL Viewer has been lacking in recent years.  As
    a result a number of bugs and glitches have not been fixed.  We
@@ -85,8 +85,18 @@ Plexil Viewer:
    process, e.g. enter 'ps -eaf | grep java' and then 'kill -9 <pid>'
    where <pid> is the process number.
 
-Plexil compiler ('plexilc'): 
+Plexil compiler ('plexilc'):
 
  * File extensions included in the '-o' option are ignored: Extended
    and Core Plexil files are always written with the ".epx" and ".plx"
    extensions, respectively.
+
+Plexil Simulator:
+
+  * Both the documentation (at
+    https://plexil-group.github.io/plexil_docs/PLEXILExecution/PLEXILSimulators.html)
+    and implementation are in need of update.  In particular the
+    simulator will not work in MacOS because it attempts to start
+    'xterm'.  Aside from this, the simulator has had long-standing
+    issues.  Fixes and enhancements from the PLEXIL community are
+    welcome!

--- a/CAVEATS
+++ b/CAVEATS
@@ -73,11 +73,10 @@ Standard Plexil language:
 
 Plexil Viewer:
 
- * Support for the PLEXIL Viewer has been lacking in recent years.  As
-   a result a number of bugs and glitches have not been fixed.  We
-   hope to have resources to spend on it soon, and welcome fixes and
-   enhancements from the PLEXIL community.  Note that PLEXIL is still
-   in strong use in its command line form.
+ * The PLEXIL Viewer (started with the 'plexil' script) is not in a
+   usable state, and has lacked support for a number of years.  We
+   welcome fixes and enhancements from the PLEXIL community.  Note
+   that PLEXIL is still in strong use in its command line form.
 
  * The viewer may not quit from the Plexil Viewer Console window,
    using the Viewer/Exit selection or the red Apple window button.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,6 @@
 # PLEXIL Release Notes
 
-## 6.0 (in development)
+## 6.0 
 
 This is a major release, with significant additions and many
 incompatible changes from the 4.x series releases.  Some existing

--- a/examples/simulator/README
+++ b/examples/simulator/README
@@ -1,14 +1,9 @@
 Example plans and scripts for the PLEXIL simulator.  See
 
-https://sourceforge.net/apps/mediawiki/plexil/index.php?title=Executing_Plans
+https://plexil-group.github.io/plexil_docs/PLEXILExecution/PLEXILSimulators.html
 
-for documentation of this simulator.
+for documentation of this simulator.  (Somewhat out of date as of 4/17/25).
 
 Each directory contains a plan with a complementary simulation script and
 interface configuration file.  See the README files in each directory for more
 information.
-
-
-
-
-

--- a/src/third-party/ipc/src/GNUmakefile
+++ b/src/third-party/ipc/src/GNUmakefile
@@ -322,7 +322,7 @@ all:: srcs libs bins privs
 #	$(LD) -r -o $@ $(ODIR)/part1.o $(ODIR)/part2.o; chmod a-x $@
 
 ifneq ($(THIS_OS),vxworks)
-$(BDIR)/central:: $(SERVEROBJS) $(LIBDEP)
+$(BDIR)/central:: $(SERVEROBJS) $(LIBDEP) $(LOCAL_LIBS)
 	@[ -d $(BDIR) ] || $(MKDIR) $(BDIR)
 	$(LINK.c) -o $@ $(SERVEROBJS) $(LIBRARIES) $(DYN_LIBRARIES)
 else

--- a/src/third-party/ipc/src/formatters.h
+++ b/src/third-party/ipc/src/formatters.h
@@ -608,9 +608,11 @@ typedef enum
 #define IPC_ALIGN ALIGN_LONGEST
 #elif defined(THINK_C) || defined(sun3) || defined(SUN3)
 #define IPC_ALIGN ALIGN_WORD
-#elif defined(macintosh) && defined(__POWERPC__)
+#elif defined(macintosh) && defined(__POWERPC__)  /* MacOS classic */
 #define IPC_ALIGN ALIGN_MAC_PPC
 #elif defined(__APPLE__) && defined(_ARCH_PPC)
+#define IPC_ALIGN ALIGN_MAC_PPC
+#elif defined(__APPLE__) && defined(__arm64__)  /* macOS on Apple silicon */
 #define IPC_ALIGN ALIGN_MAC_PPC
 #elif defined(sun4) || defined(SUN4) || defined(sparc) || defined(__sparc)
 #define IPC_ALIGN ALIGN_LONGEST
@@ -625,10 +627,11 @@ typedef enum
 /* Note, the next line is only valid for gcc, but will only be evaluated 
  * if the machine type is unknown.
  */
-#elif #machine (sparc)
-#define IPC_ALIGN ALIGN_LONGEST
-#elif #machine (arm)
-#define IPC_ALIGN ALIGN_ARM
+/* Breaks compilation on macOS Apple silicon. */
+/* #elif #machine (sparc) */
+/* #define IPC_ALIGN ALIGN_LONGEST */
+/* #elif #machine (arm) */
+/* #define IPC_ALIGN ALIGN_ARM */
 #else 
 #undef IPC_ALIGN
 #endif


### PR DESCRIPTION
Fixes IPC build issue on Apple silicon Mac. Also fixes a missing dependency in the IPC build that could break parallel builds.

Test by building 'make everything' on various platforms.