### PR TITLE
Assignments no longer induce a macro step

### DIFF
--- a/src/exec/PlexilExec.cc
+++ b/src/exec/PlexilExec.cc
@@ -368,21 +368,23 @@ namespace PLEXIL
           m_listener->notifyOfTransitions(m_transitionsToPublish);
         m_transitionsToPublish.clear();
 
+        // Perform any assignments that resulted from these transitions
+        if (!m_assignmentsToExecute.empty()
+            || !m_assignmentsToRetract.empty())
+          performAssignments();
+
         // done with this batch
 #ifndef NO_DEBUG_MESSAGE_SUPPORT 
         ++stepCount;
 #endif
       }
-      while (m_assignmentsToExecute.empty()
-             && m_assignmentsToRetract.empty()
-             && m_commandsToExecute.empty()
+      while (m_commandsToExecute.empty()
              && m_commandsToAbort.empty()
              && !m_candidateQueue.empty());
       // END QUIESCENCE LOOP
 
       // Perform side effects
       StateCache::instance().incrementCycleCount();
-      performAssignments();
       executeOutboundQueue();
       if (m_listener)
         m_listener->stepComplete(cycleNum);

--- a/test/TestExec-regression-test/run-tests
+++ b/test/TestExec-regression-test/run-tests
@@ -67,7 +67,7 @@ SAME_NAME_SCRIPT_TESTS='array1 array3 array4 array8 AtomicAssignment
  ChangeLookupTest command1 command2 command3 command4 command5 CommandCleanupTest
  concat2 conjuncts conjuncts1
  lookup1 lookup2 lookup3
- repeat2 repeat5 repeat7 repeat8
+ repeat2 repeat5 repeat7
  SiteSurveyWithEOF
  TestEndCondition TestTimepoint
  unknown_lookup UpdateLookupTest UpdateTest

--- a/test/TestExec-regression-test/valid/RUN_AssignToParentExit_empty-script.valid
+++ b/test/TestExec-regression-test/valid/RUN_AssignToParentExit_empty-script.valid
@@ -6,118 +6,82 @@ AssignToParentExit{
   }
 }
 
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
 [PlexilExec:step] ==>Start cycle 1
 [PlexilExec:step][1:0] Check queue: AssignToParentExit 
-[PlexilExec:step] Node AssignToParentExit 0x7f89aa504f20 can transition from INACTIVE to WAITING
-[PlexilExec:step] adding AssignToParentExit 0x7f89aa504f20 to state change queue
+[PlexilExec:step] Node AssignToParentExit 0x13c704080 can transition from INACTIVE to WAITING
+[PlexilExec:step] adding AssignToParentExit 0x13c704080 to state change queue
 [PlexilExec:step][1:0] State change queue: AssignToParentExit 
-[PlexilExec:step][1:0:0] Transitioning NodeList node AssignToParentExit 0x7f89aa504f20 from INACTIVE to WAITING
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
-[Node:notifyChanged] adding Kid 0x7f89aa505310 to check queue
+[PlexilExec:step][1:0:0] Transitioning NodeList node AssignToParentExit 0x13c704080 from INACTIVE to WAITING
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
+[Node:notifyChanged] adding Kid 0x13c704270 to check queue
 [PlexilExec:step][1:1] Check queue: AssignToParentExit Kid 
-[PlexilExec:step] Node AssignToParentExit 0x7f89aa504f20 can transition from WAITING to EXECUTING
-[PlexilExec:step] adding AssignToParentExit 0x7f89aa504f20 to state change queue
+[PlexilExec:step] Node AssignToParentExit 0x13c704080 can transition from WAITING to EXECUTING
+[PlexilExec:step] adding AssignToParentExit 0x13c704080 to state change queue
 [PlexilExec:step][1:1] State change queue: AssignToParentExit 
-[PlexilExec:step][1:1:0] Transitioning NodeList node AssignToParentExit 0x7f89aa504f20 from WAITING to EXECUTING
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
-[Node:notifyChanged] adding Kid 0x7f89aa505310 to check queue
+[PlexilExec:step][1:1:0] Transitioning NodeList node AssignToParentExit 0x13c704080 from WAITING to EXECUTING
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
+[Node:notifyChanged] adding Kid 0x13c704270 to check queue
 [PlexilExec:step][1:2] Check queue: AssignToParentExit Kid 
-[PlexilExec:step] Node Kid 0x7f89aa505310 can transition from INACTIVE to WAITING
-[PlexilExec:step] adding Kid 0x7f89aa505310 to state change queue
+[PlexilExec:step] Node Kid 0x13c704270 can transition from INACTIVE to WAITING
+[PlexilExec:step] adding Kid 0x13c704270 to state change queue
 [PlexilExec:step][1:2] State change queue: Kid 
-[PlexilExec:step][1:2:0] Transitioning Assignment node Kid 0x7f89aa505310 from INACTIVE to WAITING
-[Node:notifyChanged] adding Kid 0x7f89aa505310 to check queue
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
+[PlexilExec:step][1:2:0] Transitioning Assignment node Kid 0x13c704270 from INACTIVE to WAITING
+[Node:notifyChanged] adding Kid 0x13c704270 to check queue
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
 [PlexilExec:step][1:3] Check queue: Kid AssignToParentExit 
-[PlexilExec:step] Node Kid 0x7f89aa505310 can transition from WAITING to EXECUTING
-[PlexilExec:step] adding Kid 0x7f89aa505310 to pending queue
+[PlexilExec:step] Node Kid 0x13c704270 can transition from WAITING to EXECUTING
+[PlexilExec:step] adding Kid 0x13c704270 to pending queue
 [PlexilExec:step][1:3] Pending queue: Kid 
 [PlexilExec:step] processing resource reservations at priority 100000
 [PlexilExec:step] 1 nodes eligible to acquire resources
 [PlexilExec:resolveResourceConflicts] Kid succeeded
-[PlexilExec:step] adding Kid 0x7f89aa505310 to state change queue
+[PlexilExec:step] adding Kid 0x13c704270 to state change queue
 [PlexilExec:step][1:3] State change queue: Kid 
-[PlexilExec:step][1:3:0] Transitioning Assignment node Kid 0x7f89aa505310 from WAITING to EXECUTING
-[Node:notifyChanged] adding Kid 0x7f89aa505310 to check queue
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
+[PlexilExec:step][1:3:0] Transitioning Assignment node Kid 0x13c704270 from WAITING to EXECUTING
+[Node:notifyChanged] adding Kid 0x13c704270 to check queue
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
 [PlexilExec:performAssignments] performing 1 assignments and 0 retractions
-[Test:testOutput] Assigning true to (Variable Boolean step_failed 0x7f89aa505260 [a](false))
-[PlexilExec:step] ==>End cycle 1
-[PlexilExec:printPlan]
-AssignToParentExit{
- State: EXECUTING (0)
- ExitCondition: (Variable Boolean step_failed 0x7f89aa505260 [a](true))
- EndCondition: (EQ Boolean 0x7f89aa505510 [a](false) (StateVariable NodeState Kid 0x7f89aa5053e0 [a](EXECUTING)) (NodeStateValue NodeState 0x10e795c00 [a](FINISHED)))
- ActionCompleteCondition: (AllChildrenWaitingOrFinished Boolean AssignToParentExit 0x7f89aa505068 [i](false))
- step_failed: (Variable Boolean step_failed 0x7f89aa505260 [a](true))
-  Kid{
-   State: EXECUTING (0)
-   AncestorExitCondition: (Variable Boolean step_failed 0x7f89aa505260 [a](true))
-   AncestorEndCondition: (EQ Boolean 0x7f89aa505510 [a](false) (StateVariable NodeState Kid 0x7f89aa5053e0 [a](EXECUTING)) (NodeStateValue NodeState 0x10e795c00 [a](FINISHED)))
-   ActionCompleteCondition: (InternalVariable Boolean ack 0x7f89aa505460 [a](true))
-   AbortCompleteCondition: (InternalVariable Boolean abortComplete 0x7f89aa5054a0 [i](false))
-  }
-}
-
-[PlexilExec:step] ==>Start cycle 2
-[PlexilExec:step][2:0] Check queue: Kid AssignToParentExit 
-[PlexilExec:step] Node Kid 0x7f89aa505310 can transition from EXECUTING to FAILING
-[PlexilExec:step] adding Kid 0x7f89aa505310 to state change queue
-[PlexilExec:step] Node AssignToParentExit 0x7f89aa504f20 can transition from EXECUTING to FAILING
-[PlexilExec:step] adding AssignToParentExit 0x7f89aa504f20 to state change queue
-[PlexilExec:step][2:0] State change queue: Kid AssignToParentExit 
-[PlexilExec:step][2:0:0] Transitioning Assignment node Kid 0x7f89aa505310 from EXECUTING to FAILING
-[Node:notifyChanged] adding Kid 0x7f89aa505310 to check queue
-[Node:notifyChanged] transitioning node AssignToParentExit 0x7f89aa504f20 will be rechecked
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
-[PlexilExec:step][2:0:1] Transitioning NodeList node AssignToParentExit 0x7f89aa504f20 from EXECUTING to FAILING
+[Test:testOutput] Assigning true to (Variable Boolean step_failed 0x600001414000 [a](false))
+[PlexilExec:step][1:4] Check queue: Kid AssignToParentExit 
+[PlexilExec:step] Node Kid 0x13c704270 can transition from EXECUTING to FAILING
+[PlexilExec:step] adding Kid 0x13c704270 to state change queue
+[PlexilExec:step] Node AssignToParentExit 0x13c704080 can transition from EXECUTING to FAILING
+[PlexilExec:step] adding AssignToParentExit 0x13c704080 to state change queue
+[PlexilExec:step][1:4] State change queue: Kid AssignToParentExit 
+[PlexilExec:step][1:4:0] Transitioning Assignment node Kid 0x13c704270 from EXECUTING to FAILING
+[Node:notifyChanged] adding Kid 0x13c704270 to check queue
+[Node:notifyChanged] transitioning node AssignToParentExit 0x13c704080 will be rechecked
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
+[PlexilExec:step][1:4:1] Transitioning NodeList node AssignToParentExit 0x13c704080 from EXECUTING to FAILING
 [PlexilExec:performAssignments] performing 0 assignments and 1 retractions
-[Test:testOutput] Restoring previous value of (Variable Boolean step_failed 0x7f89aa505260 [a](true))
-[PlexilExec:step] ==>End cycle 2
-[PlexilExec:printPlan]
-AssignToParentExit{
- State: FAILING (0)
- ExitCondition: (Variable Boolean step_failed 0x7f89aa505260 [a](false))
- EndCondition: (EQ Boolean 0x7f89aa505510 [a](false) (StateVariable NodeState Kid 0x7f89aa5053e0 [a](FAILING)) (NodeStateValue NodeState 0x10e795c00 [a](FINISHED)))
- ActionCompleteCondition: (AllChildrenWaitingOrFinished Boolean AssignToParentExit 0x7f89aa505068 [a](false))
- step_failed: (Variable Boolean step_failed 0x7f89aa505260 [a](false))
-  Kid{
-   State: FAILING (0)
-   AncestorExitCondition: (Variable Boolean step_failed 0x7f89aa505260 [a](false))
-   AncestorEndCondition: (EQ Boolean 0x7f89aa505510 [a](false) (StateVariable NodeState Kid 0x7f89aa5053e0 [a](FAILING)) (NodeStateValue NodeState 0x10e795c00 [a](FINISHED)))
-   ActionCompleteCondition: (InternalVariable Boolean ack 0x7f89aa505460 [i](true))
-   AbortCompleteCondition: (InternalVariable Boolean abortComplete 0x7f89aa5054a0 [a](true))
-  }
-}
-
-[PlexilExec:step] ==>Start cycle 3
-[PlexilExec:step][3:0] Check queue: Kid AssignToParentExit 
-[PlexilExec:step] Node Kid 0x7f89aa505310 can transition from FAILING to FINISHED
-[PlexilExec:step] adding Kid 0x7f89aa505310 to state change queue
-[PlexilExec:step][3:0] State change queue: Kid 
-[PlexilExec:step][3:0:0] Transitioning Assignment node Kid 0x7f89aa505310 from FAILING to FINISHED
-[Node:notifyChanged] adding Kid 0x7f89aa505310 to check queue
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
-[PlexilExec:step][3:1] Check queue: Kid AssignToParentExit 
-[PlexilExec:step] Node AssignToParentExit 0x7f89aa504f20 can transition from FAILING to ITERATION_ENDED
-[PlexilExec:step] adding AssignToParentExit 0x7f89aa504f20 to state change queue
-[PlexilExec:step][3:1] State change queue: AssignToParentExit 
-[PlexilExec:step][3:1:0] Transitioning NodeList node AssignToParentExit 0x7f89aa504f20 from FAILING to ITERATION_ENDED
-[Node:notifyChanged] adding AssignToParentExit 0x7f89aa504f20 to check queue
-[PlexilExec:step][3:2] Check queue: AssignToParentExit 
-[PlexilExec:step] Node AssignToParentExit 0x7f89aa504f20 can transition from ITERATION_ENDED to FINISHED
-[PlexilExec:step] adding AssignToParentExit 0x7f89aa504f20 to state change queue
-[PlexilExec:step][3:2] State change queue: AssignToParentExit 
-[PlexilExec:step][3:2:0] Transitioning NodeList node AssignToParentExit 0x7f89aa504f20 from ITERATION_ENDED to FINISHED
-[PlexilExec:step] Marking AssignToParentExit 0x7f89aa504f20 as a finished root node
-[PlexilExec:step] ==>End cycle 3
+[Test:testOutput] Restoring previous value of (Variable Boolean step_failed 0x600001414000 [a](true))
+[PlexilExec:step][1:5] Check queue: Kid AssignToParentExit 
+[PlexilExec:step] Node Kid 0x13c704270 can transition from FAILING to FINISHED
+[PlexilExec:step] adding Kid 0x13c704270 to state change queue
+[PlexilExec:step][1:5] State change queue: Kid 
+[PlexilExec:step][1:5:0] Transitioning Assignment node Kid 0x13c704270 from FAILING to FINISHED
+[Node:notifyChanged] adding Kid 0x13c704270 to check queue
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
+[PlexilExec:step][1:6] Check queue: Kid AssignToParentExit 
+[PlexilExec:step] Node AssignToParentExit 0x13c704080 can transition from FAILING to ITERATION_ENDED
+[PlexilExec:step] adding AssignToParentExit 0x13c704080 to state change queue
+[PlexilExec:step][1:6] State change queue: AssignToParentExit 
+[PlexilExec:step][1:6:0] Transitioning NodeList node AssignToParentExit 0x13c704080 from FAILING to ITERATION_ENDED
+[Node:notifyChanged] adding AssignToParentExit 0x13c704080 to check queue
+[PlexilExec:step][1:7] Check queue: AssignToParentExit 
+[PlexilExec:step] Node AssignToParentExit 0x13c704080 can transition from ITERATION_ENDED to FINISHED
+[PlexilExec:step] adding AssignToParentExit 0x13c704080 to state change queue
+[PlexilExec:step][1:7] State change queue: AssignToParentExit 
+[PlexilExec:step][1:7:0] Transitioning NodeList node AssignToParentExit 0x13c704080 from ITERATION_ENDED to FINISHED
+[PlexilExec:step] Marking AssignToParentExit 0x13c704080 as a finished root node
+[PlexilExec:step] ==>End cycle 1
 [PlexilExec:printPlan]
 AssignToParentExit{
  State: FINISHED (0)
  Outcome: INTERRUPTED
  Failure type: EXITED
- step_failed: (Variable Boolean step_failed 0x7f89aa505260 [i]([unknown_value]))
+ step_failed: (Variable Boolean step_failed 0x600001414000 [i]([unknown_value]))
   Kid{
    State: FINISHED (0)
    Outcome: INTERRUPTED

--- a/test/TestExec-regression-test/valid/RUN_AssignToParentInvariant_empty-script.valid
+++ b/test/TestExec-regression-test/valid/RUN_AssignToParentInvariant_empty-script.valid
@@ -6,117 +6,81 @@ AssignToParentInvariant{
   }
 }
 
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
 [PlexilExec:step] ==>Start cycle 1
 [PlexilExec:step][1:0] Check queue: AssignToParentInvariant 
-[PlexilExec:step] Node AssignToParentInvariant 0x7f9b35504f20 can transition from INACTIVE to WAITING
-[PlexilExec:step] adding AssignToParentInvariant 0x7f9b35504f20 to state change queue
+[PlexilExec:step] Node AssignToParentInvariant 0x122704080 can transition from INACTIVE to WAITING
+[PlexilExec:step] adding AssignToParentInvariant 0x122704080 to state change queue
 [PlexilExec:step][1:0] State change queue: AssignToParentInvariant 
-[PlexilExec:step][1:0:0] Transitioning NodeList node AssignToParentInvariant 0x7f9b35504f20 from INACTIVE to WAITING
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
+[PlexilExec:step][1:0:0] Transitioning NodeList node AssignToParentInvariant 0x122704080 from INACTIVE to WAITING
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
 [PlexilExec:step][1:1] Check queue: AssignToParentInvariant 
-[PlexilExec:step] Node AssignToParentInvariant 0x7f9b35504f20 can transition from WAITING to EXECUTING
-[PlexilExec:step] adding AssignToParentInvariant 0x7f9b35504f20 to state change queue
+[PlexilExec:step] Node AssignToParentInvariant 0x122704080 can transition from WAITING to EXECUTING
+[PlexilExec:step] adding AssignToParentInvariant 0x122704080 to state change queue
 [PlexilExec:step][1:1] State change queue: AssignToParentInvariant 
-[PlexilExec:step][1:1:0] Transitioning NodeList node AssignToParentInvariant 0x7f9b35504f20 from WAITING to EXECUTING
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
-[Node:notifyChanged] adding Child 0x7f9b35505330 to check queue
+[PlexilExec:step][1:1:0] Transitioning NodeList node AssignToParentInvariant 0x122704080 from WAITING to EXECUTING
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
+[Node:notifyChanged] adding Child 0x122704270 to check queue
 [PlexilExec:step][1:2] Check queue: AssignToParentInvariant Child 
-[PlexilExec:step] Node Child 0x7f9b35505330 can transition from INACTIVE to WAITING
-[PlexilExec:step] adding Child 0x7f9b35505330 to state change queue
+[PlexilExec:step] Node Child 0x122704270 can transition from INACTIVE to WAITING
+[PlexilExec:step] adding Child 0x122704270 to state change queue
 [PlexilExec:step][1:2] State change queue: Child 
-[PlexilExec:step][1:2:0] Transitioning Assignment node Child 0x7f9b35505330 from INACTIVE to WAITING
-[Node:notifyChanged] adding Child 0x7f9b35505330 to check queue
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
+[PlexilExec:step][1:2:0] Transitioning Assignment node Child 0x122704270 from INACTIVE to WAITING
+[Node:notifyChanged] adding Child 0x122704270 to check queue
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
 [PlexilExec:step][1:3] Check queue: Child AssignToParentInvariant 
-[PlexilExec:step] Node Child 0x7f9b35505330 can transition from WAITING to EXECUTING
-[PlexilExec:step] adding Child 0x7f9b35505330 to pending queue
+[PlexilExec:step] Node Child 0x122704270 can transition from WAITING to EXECUTING
+[PlexilExec:step] adding Child 0x122704270 to pending queue
 [PlexilExec:step][1:3] Pending queue: Child 
 [PlexilExec:step] processing resource reservations at priority 100000
 [PlexilExec:step] 1 nodes eligible to acquire resources
 [PlexilExec:resolveResourceConflicts] Child succeeded
-[PlexilExec:step] adding Child 0x7f9b35505330 to state change queue
+[PlexilExec:step] adding Child 0x122704270 to state change queue
 [PlexilExec:step][1:3] State change queue: Child 
-[PlexilExec:step][1:3:0] Transitioning Assignment node Child 0x7f9b35505330 from WAITING to EXECUTING
-[Node:notifyChanged] adding Child 0x7f9b35505330 to check queue
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
+[PlexilExec:step][1:3:0] Transitioning Assignment node Child 0x122704270 from WAITING to EXECUTING
+[Node:notifyChanged] adding Child 0x122704270 to check queue
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
 [PlexilExec:performAssignments] performing 1 assignments and 0 retractions
-[Test:testOutput] Assigning true to (Variable Boolean step_failed 0x7f9b35505280 [a](false))
-[PlexilExec:step] ==>End cycle 1
-[PlexilExec:printPlan]
-AssignToParentInvariant{
- State: EXECUTING (0)
- InvariantCondition: (EQ Boolean 0x7f9b355055a0 [a](false) (Variable Boolean step_failed 0x7f9b35505280 [a](true)) (Constant Boolean 0x108674b10 [a](false)))
- EndCondition: (EQ Boolean 0x7f9b35505600 [a](false) (StateVariable NodeState Child 0x7f9b35505400 [a](EXECUTING)) (NodeStateValue NodeState 0x108674c00 [a](FINISHED)))
- ActionCompleteCondition: (AllChildrenWaitingOrFinished Boolean AssignToParentInvariant 0x7f9b35505068 [i](false))
- step_failed: (Variable Boolean step_failed 0x7f9b35505280 [a](true))
-  Child{
-   State: EXECUTING (0)
-   AncestorInvariantCondition: (EQ Boolean 0x7f9b355055a0 [a](false) (Variable Boolean step_failed 0x7f9b35505280 [a](true)) (Constant Boolean 0x108674b10 [a](false)))
-   AncestorEndCondition: (EQ Boolean 0x7f9b35505600 [a](false) (StateVariable NodeState Child 0x7f9b35505400 [a](EXECUTING)) (NodeStateValue NodeState 0x108674c00 [a](FINISHED)))
-   ActionCompleteCondition: (InternalVariable Boolean ack 0x7f9b355054f0 [a](true))
-   AbortCompleteCondition: (InternalVariable Boolean abortComplete 0x7f9b35505530 [i](false))
-  }
-}
-
-[PlexilExec:step] ==>Start cycle 2
-[PlexilExec:step][2:0] Check queue: Child AssignToParentInvariant 
-[PlexilExec:step] Node Child 0x7f9b35505330 can transition from EXECUTING to FAILING
-[PlexilExec:step] adding Child 0x7f9b35505330 to state change queue
-[PlexilExec:step] Node AssignToParentInvariant 0x7f9b35504f20 can transition from EXECUTING to FAILING
-[PlexilExec:step] adding AssignToParentInvariant 0x7f9b35504f20 to state change queue
-[PlexilExec:step][2:0] State change queue: Child AssignToParentInvariant 
-[PlexilExec:step][2:0:0] Transitioning Assignment node Child 0x7f9b35505330 from EXECUTING to FAILING
-[Node:notifyChanged] adding Child 0x7f9b35505330 to check queue
-[Node:notifyChanged] transitioning node AssignToParentInvariant 0x7f9b35504f20 will be rechecked
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
-[PlexilExec:step][2:0:1] Transitioning NodeList node AssignToParentInvariant 0x7f9b35504f20 from EXECUTING to FAILING
+[Test:testOutput] Assigning true to (Variable Boolean step_failed 0x600003b40000 [a](false))
+[PlexilExec:step][1:4] Check queue: Child AssignToParentInvariant 
+[PlexilExec:step] Node Child 0x122704270 can transition from EXECUTING to FAILING
+[PlexilExec:step] adding Child 0x122704270 to state change queue
+[PlexilExec:step] Node AssignToParentInvariant 0x122704080 can transition from EXECUTING to FAILING
+[PlexilExec:step] adding AssignToParentInvariant 0x122704080 to state change queue
+[PlexilExec:step][1:4] State change queue: Child AssignToParentInvariant 
+[PlexilExec:step][1:4:0] Transitioning Assignment node Child 0x122704270 from EXECUTING to FAILING
+[Node:notifyChanged] adding Child 0x122704270 to check queue
+[Node:notifyChanged] transitioning node AssignToParentInvariant 0x122704080 will be rechecked
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
+[PlexilExec:step][1:4:1] Transitioning NodeList node AssignToParentInvariant 0x122704080 from EXECUTING to FAILING
 [PlexilExec:performAssignments] performing 0 assignments and 1 retractions
-[Test:testOutput] Restoring previous value of (Variable Boolean step_failed 0x7f9b35505280 [a](true))
-[PlexilExec:step] ==>End cycle 2
-[PlexilExec:printPlan]
-AssignToParentInvariant{
- State: FAILING (0)
- InvariantCondition: (EQ Boolean 0x7f9b355055a0 [a](true) (Variable Boolean step_failed 0x7f9b35505280 [a](false)) (Constant Boolean 0x108674b10 [a](false)))
- EndCondition: (EQ Boolean 0x7f9b35505600 [a](false) (StateVariable NodeState Child 0x7f9b35505400 [a](FAILING)) (NodeStateValue NodeState 0x108674c00 [a](FINISHED)))
- ActionCompleteCondition: (AllChildrenWaitingOrFinished Boolean AssignToParentInvariant 0x7f9b35505068 [a](false))
- step_failed: (Variable Boolean step_failed 0x7f9b35505280 [a](false))
-  Child{
-   State: FAILING (0)
-   AncestorInvariantCondition: (EQ Boolean 0x7f9b355055a0 [a](true) (Variable Boolean step_failed 0x7f9b35505280 [a](false)) (Constant Boolean 0x108674b10 [a](false)))
-   AncestorEndCondition: (EQ Boolean 0x7f9b35505600 [a](false) (StateVariable NodeState Child 0x7f9b35505400 [a](FAILING)) (NodeStateValue NodeState 0x108674c00 [a](FINISHED)))
-   ActionCompleteCondition: (InternalVariable Boolean ack 0x7f9b355054f0 [i](true))
-   AbortCompleteCondition: (InternalVariable Boolean abortComplete 0x7f9b35505530 [a](true))
-  }
-}
-
-[PlexilExec:step] ==>Start cycle 3
-[PlexilExec:step][3:0] Check queue: Child AssignToParentInvariant 
-[PlexilExec:step] Node Child 0x7f9b35505330 can transition from FAILING to FINISHED
-[PlexilExec:step] adding Child 0x7f9b35505330 to state change queue
-[PlexilExec:step][3:0] State change queue: Child 
-[PlexilExec:step][3:0:0] Transitioning Assignment node Child 0x7f9b35505330 from FAILING to FINISHED
-[Node:notifyChanged] adding Child 0x7f9b35505330 to check queue
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
-[PlexilExec:step][3:1] Check queue: Child AssignToParentInvariant 
-[PlexilExec:step] Node AssignToParentInvariant 0x7f9b35504f20 can transition from FAILING to ITERATION_ENDED
-[PlexilExec:step] adding AssignToParentInvariant 0x7f9b35504f20 to state change queue
-[PlexilExec:step][3:1] State change queue: AssignToParentInvariant 
-[PlexilExec:step][3:1:0] Transitioning NodeList node AssignToParentInvariant 0x7f9b35504f20 from FAILING to ITERATION_ENDED
-[Node:notifyChanged] adding AssignToParentInvariant 0x7f9b35504f20 to check queue
-[PlexilExec:step][3:2] Check queue: AssignToParentInvariant 
-[PlexilExec:step] Node AssignToParentInvariant 0x7f9b35504f20 can transition from ITERATION_ENDED to FINISHED
-[PlexilExec:step] adding AssignToParentInvariant 0x7f9b35504f20 to state change queue
-[PlexilExec:step][3:2] State change queue: AssignToParentInvariant 
-[PlexilExec:step][3:2:0] Transitioning NodeList node AssignToParentInvariant 0x7f9b35504f20 from ITERATION_ENDED to FINISHED
-[PlexilExec:step] Marking AssignToParentInvariant 0x7f9b35504f20 as a finished root node
-[PlexilExec:step] ==>End cycle 3
+[Test:testOutput] Restoring previous value of (Variable Boolean step_failed 0x600003b40000 [a](true))
+[PlexilExec:step][1:5] Check queue: Child AssignToParentInvariant 
+[PlexilExec:step] Node Child 0x122704270 can transition from FAILING to FINISHED
+[PlexilExec:step] adding Child 0x122704270 to state change queue
+[PlexilExec:step][1:5] State change queue: Child 
+[PlexilExec:step][1:5:0] Transitioning Assignment node Child 0x122704270 from FAILING to FINISHED
+[Node:notifyChanged] adding Child 0x122704270 to check queue
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
+[PlexilExec:step][1:6] Check queue: Child AssignToParentInvariant 
+[PlexilExec:step] Node AssignToParentInvariant 0x122704080 can transition from FAILING to ITERATION_ENDED
+[PlexilExec:step] adding AssignToParentInvariant 0x122704080 to state change queue
+[PlexilExec:step][1:6] State change queue: AssignToParentInvariant 
+[PlexilExec:step][1:6:0] Transitioning NodeList node AssignToParentInvariant 0x122704080 from FAILING to ITERATION_ENDED
+[Node:notifyChanged] adding AssignToParentInvariant 0x122704080 to check queue
+[PlexilExec:step][1:7] Check queue: AssignToParentInvariant 
+[PlexilExec:step] Node AssignToParentInvariant 0x122704080 can transition from ITERATION_ENDED to FINISHED
+[PlexilExec:step] adding AssignToParentInvariant 0x122704080 to state change queue
+[PlexilExec:step][1:7] State change queue: AssignToParentInvariant 
+[PlexilExec:step][1:7:0] Transitioning NodeList node AssignToParentInvariant 0x122704080 from ITERATION_ENDED to FINISHED
+[PlexilExec:step] Marking AssignToParentInvariant 0x122704080 as a finished root node
+[PlexilExec:step] ==>End cycle 1
 [PlexilExec:printPlan]
 AssignToParentInvariant{
  State: FINISHED (0)
  Outcome: FAILURE
  Failure type: INVARIANT_CONDITION_FAILED
- step_failed: (Variable Boolean step_failed 0x7f9b35505280 [i]([unknown_value]))
+ step_failed: (Variable Boolean step_failed 0x600003b40000 [i]([unknown_value]))
   Child{
    State: FINISHED (0)
    Outcome: FAILURE


### PR DESCRIPTION
DRAFT

Make assignments take effect at end of each micro step rather than macro step. Update regression suite for changes in behavior.