### PR TITLE
Fixes for issue #10: CMake build errors

### DIFF
--- a/CAVEATS
+++ b/CAVEATS
@@ -5,10 +5,11 @@ Build:
 
  * If the GNU autotools installed on your system are a different
    version from the ones used to build this release, you may encounter
-   errors running 'make'. The following commands can replace the bad
-   files with compatible ones from your local installation:
+   errors running 'make' from $PLEXIL_HOME.  The following commands
+   can replace the bad files with compatible ones from your local
+   installation:
 
-  cd $PLEXIL_HOME/src
+  cd "${PLEXIL_HOME}/src"
   aclocal --force
   libtoolize --force --copy
   autoreconf --force --install
@@ -21,7 +22,7 @@ Build:
    particular subsystems and applications you need.
 
  * The Plexil example plans and applications (found in
-   plexil-4/examples) are NOT compiled by default.  Plans (.ple or
+   plexil/examples) are NOT compiled by default.  Plans (.ple or
    .plp files) must be compiled manually (with plexilc) to produce
    .plx files.  The application directories (examples/sample-app and
    examples/robosim) must be built by typing 'make'.
@@ -40,8 +41,8 @@ Custom builds:
    installation directory itself. E.g.:
    
    ```
-   cd $PLEXIL_HOME/src
-   ./configure --prefix=$PLEXIL_HOME [... more options ...]
+   cd "${PLEXIL_HOME}/src"
+   ./configure --prefix="${PLEXIL_HOME}" [... more options ...]
    ```
    
  * By default, the GNU autotools build both dynamic and static
@@ -52,22 +53,20 @@ Custom builds:
 
 PLEXIL executive and interfaces:
 
- * The IPC subsystem is not yet working on FreeBSD (as of PLEXIL
-   4.0.1). Unfortunately, this means many of the example applications
-   cannot be used on FreeBSD.
+ * The IPC subsystem is not supported on FreeBSD.  Unfortunately, this
+   means many of the example applications cannot be used on FreeBSD.
 
 Standard Plexil language:
 
- * Node timepoints cannot be assigned to variables.
+ * Node timepoint values cannot be assigned to variables.
 
 Plexil Viewer:
 
  * The PLEXIL Viewer (started with the 'plexil' script) is not in a
    usable state, and has lacked support for a number of years.  We
-   welcome fixes and enhancements from the PLEXIL community.  Note
-   that PLEXIL is still in strong use in its command line form.
+   welcome fixes and enhancements from the PLEXIL community.
 
- * The viewer may not quit from the Plexil Viewer Console window,
+ * The Viewer may not quit from the Plexil Viewer Console window,
    using the Viewer/Exit selection or the red Apple window button.
    These cause the application to hang, and you must kill its
    process, e.g. enter 'ps -eaf | grep java' and then 'kill -9 <pid>'
@@ -81,10 +80,11 @@ Plexil compiler ('plexilc'):
 
 Plexil Simulator:
 
-  * Both the documentation (at
-    https://plexil-group.github.io/plexil_docs/PLEXILExecution/PLEXILSimulators.html)
-    and implementation are in need of update.  In particular the
-    simulator will not work in MacOS because it attempts to start
-    'xterm'.  Aside from this, the simulator has had long-standing
-    issues.  Fixes and enhancements from the PLEXIL community are
-    welcome!
+ * Both the documentation (at
+   https://plexil-group.github.io/plexil_docs/PLEXILExecution/PLEXILSimulators.html)
+   and implementation are in need of update.  In particular the
+   'plexilsim' script will not work in macOS because it attempts to
+   start 'xterm', which is no longer included in the macOS
+   distribution.  Aside from this, the simulator has had
+   long-standing issues.  Fixes and enhancements from the PLEXIL
+   community are welcome!

--- a/CAVEATS
+++ b/CAVEATS
@@ -1,7 +1,34 @@
 This file, plexil/CAVEATS, lists known bugs and issues in this version
 of PLEXIL.
 
-Build:
+
+Build
+=====
+
+All builds
+----------
+
+ * The scripts in 'plexil/scripts' might not work with an out-of-tree
+   installation of PLEXIL, i.e. an installation target directory that
+   is not the root of the distribution checkout.  They rely on
+   $PLEXIL_HOME, which points to the distribution.  One workaround is
+   an in-tree installation, which is the default for the "simple"
+   installation described below.  Another is customization of the
+   installation directory, $PLEXIL_HOME, and the scripts, or some
+   combination thereof.  The PLEXIL team hopes to provide a solution
+   to this issue.
+
+ * Building from a git clone now requires the GNU 'gperf' perfect hash
+   utility.  The tarball download comes with the gperf-generated code
+   already generated.
+
+ * Switching between, or combining, the Autotools and CMake builds is
+   generally not possible.  If you need to switch build types, first
+   clean the distribution of any build products.
+
+
+Autotools builds
+----------------
 
  * If the GNU autotools installed on your system are a different
    version from the ones used to build this release, you may encounter
@@ -9,10 +36,10 @@ Build:
    can replace the bad files with compatible ones from your local
    installation:
 
-  cd "${PLEXIL_HOME}/src"
-  aclocal --force
-  libtoolize --force --copy
-  autoreconf --force --install
+   cd "${PLEXIL_HOME}/src"
+   aclocal --force
+   libtoolize --force --copy
+   autoreconf --force --install
 
    You should be able to re-run 'configure' and 'make' successfully at
    this point.
@@ -27,40 +54,71 @@ Build:
    .plx files.  The application directories (examples/sample-app and
    examples/robosim) must be built by typing 'make'.
 
-Custom builds:
-
- * Building from a git clone now requires the GNU 'gperf' perfect hash
-   utility.  The tarball download comes with the gperf-generated code
-   already generated.
-
  * The default installation location for PLEXIL libraries and
    executables under the GNU autotools is /usr/local.  The
    installation locations can be specified with the '--prefix=',
    '--bindir=', '--libdir=', and '--includedir=' options to
    'configure'.  We suggest installing these files in the PLEXIL
    installation directory itself. E.g.:
-   
+
    ```
    cd "${PLEXIL_HOME}/src"
    ./configure --prefix="${PLEXIL_HOME}" [... more options ...]
    ```
-   
+
  * By default, the GNU autotools build both dynamic and static
    libraries. This consumes time and disk space. Unless your
    application specifically requires both, we recommend that you build
    only the libraries you need. This is done by supplying the
    '--disable-static' or '--disable-dynamic' option to 'configure'.
 
-PLEXIL executive and interfaces:
+CMake builds
+------------
 
- * The IPC subsystem is not supported on FreeBSD.  Unfortunately, this
-   means many of the example applications cannot be used on FreeBSD.
+ * The compilers are not included in this build.  If you started from
+   a pure source code distribution, cd to plexil/compilers/plexil and
+   type 'ant'; then repeat this in the sibling 'plexilscript'
+   directory.
 
-Standard Plexil language:
+ * The top level Makefile is modified by this build.  Its default
+   version is for the Autotools build.  This is mainly a nuiscance
+   that needs a fix.  It can be restored with:
+
+   git checkout -- Makefile
+
+ * The following warnings appear during the build, but should be safe
+   to ignore:
+
+    plexil/src/intfc/InterfaceError.cc:77:3: warning: function
+    declared 'noreturn' should not return [-Winvalid-noreturn]
+
+    plexil/src/utils/PlanError.cc:77:3: warning: function declared
+    'noreturn' should not return [-Winvalid-noreturn]
+
+    plexil/src/utils/Error.cc:119:3: warning: function declared
+    'noreturn' should not return [-Winvalid-noreturn]
+
+
+PLEXIL executive and interfaces
+===============================
+
+ * The IPC subsystem has not been supported or maintained for some
+   time.  It may not build on FreeBSD and some Linux variants
+   including Ubuntu.  Unfortunately, this means many of the example
+   applications cannot be used on these platforms.
+
+
+Standard Plexil language
+========================
 
  * Node timepoint values cannot be assigned to variables.
 
-Plexil Viewer:
+ * Arithmetic expressions of node timepoint values cannot include Date
+   or Duration typed operands -- only Real or Integer may be used.
+
+
+Plexil Viewer
+=============
 
  * The PLEXIL Viewer (started with the 'plexil' script) is not in a
    usable state, and has lacked support for a number of years.  We
@@ -72,13 +130,17 @@ Plexil Viewer:
    process, e.g. enter 'ps -eaf | grep java' and then 'kill -9 <pid>'
    where <pid> is the process number.
 
-Plexil compiler ('plexilc'):
+
+Plexil compiler ('plexilc')
+===========================
 
  * File extensions included in the '-o' option are ignored: Extended
    and Core Plexil files are always written with the ".epx" and ".plx"
    extensions, respectively.
 
-Plexil Simulator:
+
+Plexil Simulator
+================
 
  * Both the documentation (at
    https://plexil-group.github.io/plexil_docs/PLEXILExecution/PLEXILSimulators.html)

--- a/CAVEATS
+++ b/CAVEATS
@@ -20,9 +20,6 @@ Build:
    instructions on how to use the 'configure' script to select the
    particular subsystems and applications you need.
 
- * If CMake is used in place of the GNU autotools, CMake 3.6 or newer
-   is required.
-
  * The Plexil example plans and applications (found in
    plexil-4/examples) are NOT compiled by default.  Plans (.ple or
    .plp files) must be compiled manually (with plexilc) to produce
@@ -41,25 +38,17 @@ Custom builds:
    '--bindir=', '--libdir=', and '--includedir=' options to
    'configure'.  We suggest installing these files in the PLEXIL
    installation directory itself. E.g.:
-
- cd $PLEXIL_HOME/src
- ./configure --prefix=$PLEXIL_HOME [... more options ...]
-
- * Likewise, CMake defaults to /usr/local as its installation prefix.
-   Use the '-DCMAKE_INSTALL_PREFIX=/another/directory' option on the
-   'cmake' command line to install to a different location.
-
- * In-tree CMake builds are possible, but are not recommended.
-
+   
+   ```
+   cd $PLEXIL_HOME/src
+   ./configure --prefix=$PLEXIL_HOME [... more options ...]
+   ```
+   
  * By default, the GNU autotools build both dynamic and static
    libraries. This consumes time and disk space. Unless your
    application specifically requires both, we recommend that you build
    only the libraries you need. This is done by supplying the
    '--disable-static' or '--disable-dynamic' option to 'configure'.
-
- * CMake defaults to building dynamic libraries. To build static
-   libraries, specify the '-DBUILD_SHARED_LIBS=OFF' option on the
-   'cmake' command line.
 
 PLEXIL executive and interfaces:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,7 @@
 ## TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 ## USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
-
-# explicitly set certain policies
-cmake_policy(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(Plexil
   DESCRIPTION "The PLEXIL Executive package"

--- a/README.md
+++ b/README.md
@@ -200,14 +200,14 @@ cd plexil-build
    `$PLEXIL_HOME/CMakeLists.txt` for default settings.
 
 ```
-cmake -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME $PLEXIL_HOME
+cmake "${PLEXIL_HOME}" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}"
 ```
 
 Here's a recommended configuration that adds in some useful tools:
 
 ```
-cmake -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME -DSTANDALONE_SIMULATOR=ON \
-  -DTEST_EXEC=ON -DUDP_ADAPTER=ON $PLEXIL_HOME
+cmake "${PLEXIL_HOME}" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}" \
+  -DSTANDALONE_SIMULATOR=ON -DTEST_EXEC=ON -DUDP_ADAPTER=ON
 ```
 
 CMake defaults to building dynamic libraries. To build static

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See https://plexil-group.github.io/plexil_docs/ for information about
 this software, including its user manuals.  There is more information
 in the README files found in the subdirectories.
 
-The Versions file describes previous releases of Plexil, as well as
+The Versions file describes previous releases of PLEXIL, as well as
 the latest features not yet released in a binary distribution.
 
 The CAVEATS file describes known problems and issues in this release.
@@ -37,8 +37,8 @@ software:
 If you downloaded a tarball, the GNU autotools and gperf are not
 needed.
 
-The robosim example program also requires the X11 libraries freeglut,
-libxi, libxmu and their header files.
+The robosim example program also requires the X11 libraries `freeglut`,
+`libxi`, `libxmu` and their header files.
 
 ## How to build PLEXIL - Simple version
 
@@ -64,7 +64,7 @@ Set `PLEXIL_HOME` to the directory containing this README.md file.
 
 ```
 export PLEXIL_HOME='/where/i/cloned/plexil'
-. "$PLEXIL_HOME/scripts/plexil-setup.sh"
+. "${PLEXIL_HOME}/scripts/plexil-setup.sh"
 ```
 
 2. Source the init file you just edited:
@@ -97,8 +97,8 @@ plexiltest -p my-plan.plx -s my-script.psx
 ```
 
 5. The `plexilexec` script runs the Universal Executive on a plan and
-requires an interface configuration file. See the Sourceforge
-documentation for more information.
+requires an interface configuration file. See the online documentation
+for more information.
 
 ```
 plexilexec -c interface-config.xml -p my-plan.plx`
@@ -130,7 +130,7 @@ changed.
 1. Create the script 'src/configure':
 
 ```
-cd "$PLEXIL_HOME"
+cd "${PLEXIL_HOME}"
 make src/configure
 ```
 
@@ -149,7 +149,7 @@ in the PLEXIL installation directory.  You can omit or change
 options as desired.
 
 ```
-./configure --prefix="$PLEXIL_HOME" --disable-static --enable-ipc \
+./configure --prefix="${PLEXIL_HOME}" --disable-static --enable-ipc \
  --enable-sas --enable-test-exec --enable-udp
 ```
 
@@ -194,18 +194,18 @@ cd plexil-build
    installs them in `plexil-build` is the following:
 
 ```
-cmake $PLEXIL_HOME/plexil/src -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME
+cmake "${PLEXIL_HOME}/plexil/src" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}"
 ```
 
 Here's a recommended configuration that adds in some useful tools:
 
 ```
-cmake $PLEXIL_HOME/src -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME \
+cmake "${PLEXIL_HOME}/src" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}" \
  -DSTANDALONE_SIMULATOR=ON -DTEST_EXEC=ON -DUDP_ADAPTER=ON
  ```
 
 CMake defaults to building dynamic libraries. To build static
-libraries, specify the '-DBUILD_SHARED_LIBS=OFF' option.
+libraries, specify the `-DBUILD_SHARED_LIBS=OFF` option.
 
 3. Build and install the system:
 

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ Using CMake
 -----------
 
 The PLEXIL Executive also supports building with CMake, for simpler
-integration into CMake-based projects.  CMake version 3.6 or newer is
-required.  The instructions here describe an out-of-tree build, which
-is the preferred approach.  In-tree builds should also work, but are
-not recommended.
+integration into CMake-based projects.  CMake version 3.10 or newer is
+required.  These instructions describe an out-of-tree build, which is
+the preferred approach.  In-tree builds should also work, but are not
+recommended.
 
 1. Create a build directory and change into it.
 
@@ -185,25 +185,29 @@ mkdir plexil-build
 cd plexil-build
 ```
 
-2. Configure the build using CMake.
+2. Configure the build using CMake.  By default CMake installs build
+   products in `/usr/local`.  Use the
+   `-DCMAKE_INSTALL_PREFIX=/another/directory` option on the 'cmake'
+   command line to install to a different location.  A minimal
+   configuration that performs a default build (see
+   `$PLEXIL_HOME/CMakeLists.txt` for the default settings) and
+   installs them in `plexil-build` is the following:
 
 ```
-cmake "path/to/plexil/src" -DCMAKE_INSTALL_PREFIX="/install/here" ... options ...
+cmake $PLEXIL_HOME/plexil/src -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME
 ```
 
-The example below includes all the optional PLEXIL components as built
-in the previous section, with binaries and libraries installed in the
-PLEXIL installation directory.  You can omit or change options as
-desired.
+Here's a recommended configuration that adds in some useful tools:
 
 ```
-cmake path/to/plexil/src -DCMAKE_INSTALL_PREFIX="$PLEXIL_HOME" \
+cmake $PLEXIL_HOME/src -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME \
  -DSTANDALONE_SIMULATOR=ON -DTEST_EXEC=ON -DUDP_ADAPTER=ON
  ```
 
-Please see the CAVEATS file in this directory for advice on CMake options.
+CMake defaults to building dynamic libraries. To build static
+libraries, specify the '-DBUILD_SHARED_LIBS=OFF' option.
 
-4. Build and install the system:
+3. Build and install the system:
 
 ```
 make install

--- a/README.md
+++ b/README.md
@@ -172,46 +172,53 @@ make
 Using CMake
 -----------
 
-The PLEXIL Executive also supports building with CMake, for simpler
+The PLEXIL Executive supports building with CMake, for simpler
 integration into CMake-based projects.  CMake version 3.10 or newer is
-required.  These instructions describe an out-of-tree build, which is
-the preferred approach.  In-tree builds should also work, but are not
-recommended.
+required.  Though the legacy in-tree build of PLEXIL (i.e. built
+directly in its source code checkout) should work, an out-of-tree
+build is strongly recommended and is best practice for CMake.
 
-1. Create a build directory and change into it.
+However, out-of-tree _installations_ have a problem with respect to
+PLEXIL's runtime scripts.  See the CAVEATS file for more information
+on this, and other CMake build issues.  In this section we'll describe
+an out-of-tree build with an in-tree installation.
+
+1. Create a build directory and change into it.  This can have any
+name and be in any writable location, including the root of the PLEXIL
+distribution.
+
 
 ```
 mkdir plexil-build
 cd plexil-build
 ```
 
-2. Configure the build using CMake.  By default CMake installs build
-   products in `/usr/local`.  Use the
-   `-DCMAKE_INSTALL_PREFIX=/another/directory` option on the 'cmake'
-   command line to install to a different location.  A minimal
-   configuration that performs a default build (see
-   `$PLEXIL_HOME/CMakeLists.txt` for the default settings) and
-   installs them in `plexil-build` is the following:
+2. Configure the build using CMake.  By default CMake installs in
+   `/usr/local`, but we'll use the distribution directory whose
+   location is assumed to be the value of the PLEXIL_HOME environment
+   variable.  The following line configures a minimal build.  See
+   `$PLEXIL_HOME/CMakeLists.txt` for default settings.
 
 ```
-cmake "${PLEXIL_HOME}" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}"
+cmake -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME $PLEXIL_HOME
 ```
 
 Here's a recommended configuration that adds in some useful tools:
 
 ```
-cmake "${PLEXIL_HOME}" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}" \
- -DSTANDALONE_SIMULATOR=ON -DTEST_EXEC=ON -DUDP_ADAPTER=ON
- ```
+cmake -DCMAKE_INSTALL_PREFIX=$PLEXIL_HOME -DSTANDALONE_SIMULATOR=ON \
+  -DTEST_EXEC=ON -DUDP_ADAPTER=ON $PLEXIL_HOME
+```
 
 CMake defaults to building dynamic libraries. To build static
 libraries, specify the `-DBUILD_SHARED_LIBS=OFF` option.
 
-3. Build and install the system:
+3. Build and install the system.  From the 'plexil-build' directory:
 
 ```
 make install
 ```
+
 
 ## Cross-compiling the PLEXIL Executive
 

--- a/README.md
+++ b/README.md
@@ -194,13 +194,13 @@ cd plexil-build
    installs them in `plexil-build` is the following:
 
 ```
-cmake "${PLEXIL_HOME}/plexil/src" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}"
+cmake "${PLEXIL_HOME}" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}"
 ```
 
 Here's a recommended configuration that adds in some useful tools:
 
 ```
-cmake "${PLEXIL_HOME}/src" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}" \
+cmake "${PLEXIL_HOME}" -DCMAKE_INSTALL_PREFIX="${PLEXIL_HOME}" \
  -DSTANDALONE_SIMULATOR=ON -DTEST_EXEC=ON -DUDP_ADAPTER=ON
  ```
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,20 @@
 # PLEXIL Release Notes
 
+## 6.1.3
+
+- Updated pugixml to release v1.15.
+
+- Fix various build issues when `NO_DEBUG_MESSAGE_SUPPORT` macro is
+  defined.
+
+- Fix several CMake build system issues.
+
+- Move CMake build instructions from `CAVEATS` to `README.md`.  Other
+  minor edits to these files.
+
+- Fix a missing destructor method for `std::unique_ptr<PLEXIL::Array>`
+  when using Apple `clang++` compiler.
+
 ## 6.1.2
 
 - Removed obsolete `UPDATES.TODO.md` file and `workshop` directory.

--- a/src/app-framework/CMakeLists.txt
+++ b/src/app-framework/CMakeLists.txt
@@ -55,10 +55,6 @@ if(PlexilExec_SHLIB_INSTALL_RPATH)
     PROPERTIES INSTALL_RPATH ${PlexilExec_SHLIB_INSTALL_RPATH})
 endif()
 
-if(WITH_THREADS AND HAVE_LIBPTHREAD)
-  target_link_libraries(PlexilAppFramework PUBLIC pthread)
-endif()
-
 if(HAVE_LIBDISPATCH)
   target_link_libraries(PlexilAppFramework PUBLIC dispatch)
 endif()

--- a/src/app-framework/test/timebase-test.cc
+++ b/src/app-framework/test/timebase-test.cc
@@ -25,7 +25,7 @@
 
 #include "plexil-config.h"
 
-#include "DebugMessage.hh"
+#include "Debug.hh"
 #include "InterfaceError.hh"
 #include "ThreadSemaphore.hh"
 #include "TimebaseFactory.hh"

--- a/src/apps/TestExec/TestExternalInterface.cc
+++ b/src/apps/TestExec/TestExternalInterface.cc
@@ -44,10 +44,10 @@
 
 #include <limits>
 #include <sstream>
-
-#ifdef STDC_HEADERS
 #include <cstring>
-#endif
+
+using std::strcmp;
+using std::strlen;
 
 namespace PLEXIL
 {
@@ -77,7 +77,7 @@ namespace PLEXIL
     checkError(g_exec, "Attempted to run a script without an executive.");
 
     handleInitialState(input); // steps exec once
-    
+
     pugi::xml_node script = input.child("Script");
     checkError(!script.empty(), "No Script element in Plexilscript.");
     pugi::xml_node scriptElement = script.first_child();
@@ -101,7 +101,7 @@ namespace PLEXIL
       else if (strcmp(scriptElement.name(), "CommandAck") == 0) {
         handleCommandAck(scriptElement);
       }
-         
+
       // command abort
       else if (strcmp(scriptElement.name(), "CommandAbort") == 0) {
         handleCommandAbort(scriptElement);
@@ -132,7 +132,7 @@ namespace PLEXIL
         reportParserException("Unknown script element '" << scriptElement.name() << "'");
         return;
       }
-         
+
       // step the exec forward
       if (true /* g_exec->processQueue() */ ) // *** FIXME ***
         g_exec->step(StateCache::currentTime());
@@ -183,7 +183,7 @@ namespace PLEXIL
     Value value = parseResult(elt);
     debugMsg("Test:testOutput",
              "Sending command result " << getText(command, value));
-    StateCommandMap::iterator it = 
+    StateCommandMap::iterator it =
       m_executingCommands.find(command);
     checkError(it != m_executingCommands.end(),
                "No currently executing command " << getText(command));
@@ -203,7 +203,7 @@ namespace PLEXIL
     debugMsg("Test:testOutput",
              "Sending command ACK " << getText(command, value));
     StateCommandMap::iterator it = m_commandAcks.find(command);
-    assertTrueMsg(it != m_commandAcks.end(), 
+    assertTrueMsg(it != m_commandAcks.end(),
                   "No command waiting for acknowledgement " << getText(command));
     commandHandleReturn(it->second, handle);
   }
@@ -217,12 +217,12 @@ namespace PLEXIL
     Boolean ack;
     assertTrueMsg(value.getValue(ack),
                   "CommmandAbort value must not be unknown");
-    
+
     debugMsg("Test:testOutput",
              "Sending abort ACK " << getText(command, value));
-    StateCommandMap::iterator it = 
+    StateCommandMap::iterator it =
       m_abortingCommands.find(command);
-    assertTrueMsg(it != m_abortingCommands.end(), 
+    assertTrueMsg(it != m_abortingCommands.end(),
                   "No abort waiting for acknowledgement " << getText(command));
     debugMsg("Test:testOutput",
              "Acknowledging abort into " << it->second);
@@ -249,7 +249,7 @@ namespace PLEXIL
 
     pugi::xml_document* doc = new pugi::xml_document();
     pugi::xml_parse_result parseResult = doc->load_file(filename);
-    assertTrueMsg(parseResult.status == pugi::status_ok, 
+    assertTrueMsg(parseResult.status == pugi::status_ok,
                   "Error parsing plan file " << elt.attribute("file").value()
                   << ": " << parseResult.description());
 
@@ -367,7 +367,7 @@ namespace PLEXIL
     }
   }
 
-  static void parseParams(pugi::xml_node const root, 
+  static void parseParams(pugi::xml_node const root,
                           std::vector<Value>& dest)
   {
     size_t n = std::distance(root.begin(), root.end());
@@ -454,7 +454,7 @@ namespace PLEXIL
   }
 
   // parse in value
-  static Value parseOneValue(const std::string& type, 
+  static Value parseOneValue(const std::string& type,
                              const std::string& valStr)
   {
     // Unknown

--- a/src/exec/PlexilExec.cc
+++ b/src/exec/PlexilExec.cc
@@ -256,9 +256,9 @@ namespace PLEXIL
       // Queue had better be empty when we get here!
       checkError(m_stateChangeQueue.empty(), "State change queue not empty at entry");
 
+      unsigned int cycleNum = StateCache::instance().getCycleCount();
 #ifndef NO_DEBUG_MESSAGE_SUPPORT 
       // Only used in debugMsg calls
-      unsigned int cycleNum = StateCache::instance().getCycleCount();
       unsigned int stepCount = 0;
       unsigned int microStepCount = 0;
 #endif

--- a/src/exec/test/module-tests.cc
+++ b/src/exec/test/module-tests.cc
@@ -26,7 +26,7 @@
 
 #include "plexil-config.h"
 
-#include "DebugMessage.hh"
+#include "Debug.hh"
 #include "TestSupport.hh"
 #include "lifecycle-utils.h"
 

--- a/src/expr/test/expr-test-module.cc
+++ b/src/expr/test/expr-test-module.cc
@@ -26,7 +26,7 @@
 
 #include "plexil-config.h"
 
-#include "DebugMessage.hh"
+#include "Debug.hh"
 #include "Error.hh"
 #include "TestSupport.hh"
 #include "lifecycle-utils.h"

--- a/src/interfaces/UdpAdapter/CMakeLists.txt
+++ b/src/interfaces/UdpAdapter/CMakeLists.txt
@@ -31,9 +31,8 @@ add_library(UdpUtils ${PlexilExec_SHARED_OR_STATIC}
 target_include_directories(UdpUtils PUBLIC
   ${PlexilExec_SOURCE_DIR}/utils)
 
-# No link dependencies here
-# target_link_libraries(UdpUtils PUBLIC
-#   )
+target_link_libraries(UdpUtils PUBLIC
+  PlexilUtils)
 
 install(FILES 
   UdpEventLoop.hh udp-utils.hh

--- a/src/intfc/test/intfc-test-module.cc
+++ b/src/intfc/test/intfc-test-module.cc
@@ -26,7 +26,7 @@
 
 #include "plexil-config.h"
 
-#include "DebugMessage.hh"
+#include "Debug.hh"
 #include "lifecycle-utils.h"
 #include "TestSupport.hh"
 

--- a/src/plexil-config.cmake
+++ b/src/plexil-config.cmake
@@ -108,7 +108,6 @@ int main(int argc, char ** /* argv */)
 
 # POSIX headers
 CHECK_INCLUDE_FILE(dlfcn.h HAVE_DLFCN_H)
-CHECK_INCLUDE_FILE(fcntl.h HAVE_FCNTL_H)
 CHECK_INCLUDE_FILE(pthread.h HAVE_PTHREAD_H)
 CHECK_INCLUDE_FILE(semaphore.h HAVE_SEMAPHORE_H)
 CHECK_INCLUDE_FILE(unistd.h HAVE_UNISTD_H)
@@ -121,6 +120,10 @@ CHECK_INCLUDE_FILE(arpa/inet.h HAVE_ARPA_INET_H)
 CHECK_INCLUDE_FILE(netinet/in.h HAVE_NETINET_IN_H)
 CHECK_INCLUDE_FILE(sys/socket.h HAVE_SYS_SOCKET_H)
 
+# Used only by Sockets interface library
+CHECK_INCLUDE_FILE(fcntl.h HAVE_FCNTL_H)
+CHECK_INCLUDE_FILE(sockLib.h HAVE_SOCKLIB_H)
+
 # glibc backtrace functionality
 CHECK_INCLUDE_FILE(execinfo.h HAVE_EXECINFO_H)
 
@@ -131,7 +134,6 @@ CHECK_INCLUDE_FILE(dispatch/dispatch.h HAVE_DISPATCH_DISPATCH_H)
 CHECK_INCLUDE_FILE(mach/semaphore.h HAVE_MACH_SEMAPHORE_H)
 
 # Old vxWorks
-CHECK_INCLUDE_FILE(sockLib.h HAVE_SOCKLIB_H)
 CHECK_INCLUDE_FILE(sysLib.h HAVE_SYSLIB_H)
 CHECK_INCLUDE_FILE(vxWorks.h HAVE_VXWORKS_H)
 CHECK_INCLUDE_FILE(sys/times.h HAVE_SYS_TIMES_H)
@@ -281,6 +283,8 @@ if(NOT WITH_THREADS)
   unset(PLEXIL_WITH_THREADS CACHE)
 elseif(NOT HAVE_PTHREAD_H)
   message(FATAL_ERROR "WITH_THREADS option enabled, but pthread.h not found.")
+elseif(NOT HAVE_LIBPTHREAD)
+  message(FATAL_ERROR "WITH_THREADS option enabled, but no pthreads library found.")
 else()
   set(PLEXIL_WITH_THREADS ON)
 endif()

--- a/src/third-party/ipc/CMakeLists.txt
+++ b/src/third-party/ipc/CMakeLists.txt
@@ -33,7 +33,7 @@
 #  - Languages other than C
 #  - Operating systems other than macOS (Darwin) or Linux
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(ipc C)
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -64,7 +64,7 @@ if(${WITH_THREADS})
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
-if(NOT NO_DEBUG_MESSAGE_SUPPORT)
+if(DEBUG_MESSAGES)
   target_sources(PlexilUtils PRIVATE DebugMessage.cc)
   install(FILES DebugMessage.hh
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/value/Value.hh
+++ b/src/value/Value.hh
@@ -31,11 +31,10 @@
 
 #include <memory> // std::unique_ptr
 
-// Explicit instantiation
 namespace std
 {
-  template class unique_ptr<PLEXIL::Array>;
-  template class unique_ptr<PLEXIL::String>;
+  // clang on macOS 15.x requires this explicit instantiation.
+  template unique_ptr<PLEXIL::Array>::~unique_ptr();
 }
 
 namespace PLEXIL

--- a/src/xml-parser/CMakeLists.txt
+++ b/src/xml-parser/CMakeLists.txt
@@ -81,7 +81,6 @@ install(TARGETS analyzePlan
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 target_link_libraries(analyzePlan PRIVATE
-  PlexilUtils PlexilValue PlexilExpr PlexilIntfc PlexilExec
   pugixml PlexilXmlParser)
 
 if(PlexilExec_EXE_INSTALL_RPATH)

--- a/src/xml-parser/analyzePlan.cc
+++ b/src/xml-parser/analyzePlan.cc
@@ -24,7 +24,7 @@
 * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "DebugMessage.hh"
+#include "Debug.hh"
 #include "Error.hh"
 #include "NodeImpl.hh"
 #include "lifecycle-utils.h"
@@ -394,7 +394,7 @@ int main(int argc, char *argv[])
     usage();
     return 1;
   }
-  
+
   std::ifstream config(debugConfig.c_str());
   if (config.good()) {
     PLEXIL::readDebugConfigStream(config);

--- a/src/xml-parser/test/benchmark.cc
+++ b/src/xml-parser/test/benchmark.cc
@@ -26,7 +26,7 @@
 
 #include "plexil-config.h"
 
-#include "DebugMessage.hh"
+#include "Debug.hh"
 #include "Error.hh"
 #include "NodeImpl.hh"
 #include "lifecycle-utils.h"

--- a/src/xml-parser/test/parser-test-module.cc
+++ b/src/xml-parser/test/parser-test-module.cc
@@ -24,7 +24,7 @@
 * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "DebugMessage.hh"
+#include "Debug.hh"
 #include "lifecycle-utils.h"
 #include "PlanError.hh"
 #include "SymbolTable.hh"


### PR DESCRIPTION
Addresses several issues reported in issue #10:

- Updates CMake files to work with version 4.x - minimum version required is now 3.10
- Fixes "undefined variable" error in PlexilExec.cc when `NO_DEBUG_MESSAGE_SUPPORT` defined
- Fixes a missing destructor method error for `std::unique_ptr<PLEXIL::Array>`
- Fixes a mistaken `#include` file reference in src/xml-parser/analyzePlan.cc

Also updates the `pugixml` submodule to the current release, v1.15.